### PR TITLE
Fix Keshet 12 live streams (dead /direct/ paths; hearing-impaired feed moved to CloudFront)

### DIFF
--- a/zips/plugin.video.idanplus/channels.json
+++ b/zips/plugin.video.idanplus/channels.json
@@ -46,7 +46,7 @@
 		"tvgID": "12",
 		"type": "tv",
 		"linkDetails": {
-			"link": "/direct/hls/live/2033791/k12/index.m3u8?as=1"
+			"link": "/stream/hls/live/2033791/k12/index.m3u8?as=1"
 		}
 	},
 	"ch_12b": {
@@ -70,7 +70,7 @@
 		"tvgID": "12",
 		"type": "tv",
 		"linkDetails": {
-			"link": "/direct/hls/live/2033791/k12dvr/index.m3u8?b-in-range=800-2700"
+			"link": "/stream/hls/live/2033791/k12dvr/index.m3u8?b-in-range=800-2700"
 		}
 	},
 	"ch_12b3": {
@@ -82,7 +82,7 @@
 		"tvgID": "12",
 		"type": "tv",
 		"linkDetails": {
-			"link": "/n12/hls/live/2103938/k12/index.m3u8?b-in-range=0-1100"
+			"link": "/n12/hls/live/20000821/k12rh/index.m3u8?b-in-range=0-1100"
 		}
 	},
 	"ch_12c": {

--- a/zips/plugin.video.idanplus/channels.json
+++ b/zips/plugin.video.idanplus/channels.json
@@ -94,7 +94,9 @@
 		"tvgID": "12",
 		"type": "tv",
 		"linkDetails": {
-			"link": "/direct/hls/live/2035325/k12cc/index.m3u8?as=1"
+			"link": "/k12cc/index.m3u8?b-in-range=0-800",
+			"host": "https://d2249b6f08tjt0.cloudfront.net",
+			"cdn": "AWS"
 		}
 	},
 	"ch_13": {


### PR DESCRIPTION
## Problem

All Keshet 12 live entries except `ch_12b` are dead. The failure is easy to misread, because **the master playlists still return HTTP 200**: Akamai keeps serving cached playlist objects for retired paths while every media segment 404s.

The user-visible symptom is that playback hangs for ~20 seconds and then fails with:

```
error <general>: CVideoPlayer::OpenDemuxStream - Error creating demuxer
```

A `curl` check on the `.m3u8` looks perfectly healthy, which is why this can appear to be a Kodi or inputstream problem rather than a dead path.

Root cause: mako retired the `/direct/` route for origin `2033791`, retired origin `2103938` entirely, and moved the hearing-impaired feed off Akamai altogether. `ch_12b` was the only entry already on `/stream/`, which is exactly why it was the sole survivor.

## Evidence

Every path below was tested through the full addon chain (entitlements ticket → master → best variant → **first and last segment**), and liveness was confirmed via `#EXT-X-PROGRAM-DATE-TIME` against wall clock plus a `#EXT-X-MEDIA-SEQUENCE` recheck 7 s later. Tickets returned `caseId:1` for all five entries, so this is **not** an auth, DRM or geo problem.

| Entry | Current path | Master | Variant | Segments | Verdict |
|---|---|---|---|---|---|
| `ch_12` | `/direct/…/2033791/k12/…` | 200 | 200 | **404** | dead — playlist 112 h stale |
| `ch_12b` | `/stream/…/2033791/k12n12wad/…` | 200 | 200 | 206 | alive (unchanged) |
| `ch_12b2` | `/direct/…/2033791/k12dvr/…` | 200 | 200 | **404** | dead — playlist 116 h stale |
| `ch_12b3` | `/n12/…/2103938/k12/…` | 200 | **404** | — | dead — origin retired |
| `ch_12c` | `/direct/…/2035325/k12cc/…` | 200 | **404** | — | dead — moved to CloudFront |

After the change, all five resolve to live media (variant 200, segments HTTP 206 with data, `MEDIA-SEQUENCE` advancing, no `EXT-X-ENDLIST`):

| Entry | New path | CDN | Segments |
|---|---|---|---|
| `ch_12` | `/stream/hls/live/2033791/k12/index.m3u8` | AKAMAI | 13 |
| `ch_12b` | *unchanged* | AKAMAI | 599 |
| `ch_12b2` | `/stream/hls/live/2033791/k12dvr/index.m3u8` | AKAMAI | 2398 |
| `ch_12b3` | `/n12/hls/live/20000821/k12rh/index.m3u8` | AKAMAI | 10 |
| `ch_12c` | `d2249b6f08tjt0.cloudfront.net/k12cc/index.m3u8` | **AWS** | 10 |

For `ch_12` I chose `/stream/…/k12` (13 segments, live edge) rather than a DVR path, so playback starts at the live edge instead of hours behind.

## The two commits

**1 — `/direct/` → `/stream/` route migration.** Self-contained, pure config, **works with v4.0.0 exactly as released**. Fixes `ch_12`, `ch_12b2`, `ch_12b3`. Safe to merge on its own.

**2 — `ch_12c` to CloudFront.** Requires the small code change below. mako's own captions page (`mako-vod-live-tv/VOD-319a699f834e661006.htm`, which the main live page does not link to) now serves:

```
https://d2249b6f08tjt0.cloudfront.net/k12cc/index.m3u8?b-in-range=0-800
```

That needs an **AWS**-vendor ticket (`rv=AWS`) and a non-Akamai host, both of which `WatchLive()` currently hardcodes. **Please hold commit 2 until the code patch lands** — commit 1 stands alone.

## Required code change for commit 2

I could not include this as a file change: the addon source only exists inside `plugin.video.idanplus-4.0.0.zip` in this repo, and committing a rebuilt 3.2 MB binary zip would be unreviewable. Patch for `resources/lib/keshet.py`, `WatchLive()`:

```python
 	url = linkDetails['link']
-	ticket = GetTicket('{0}?et=ngt&lp={1}&rv=AKAMAI'.format(entitlementsServices, url), headers)
+	host = linkDetails.get('host', 'https://mako-streaming.akamaized.net')
+	cdn = linkDetails.get('cdn', 'AKAMAI')
+	ticket = GetTicket('{0}?et=ngt&lp={1}&rv={2}'.format(entitlementsServices, url, cdn), headers)
+	if ticket is None:
+		xbmc.log('WatchLive: no ticket for channel {0} (cdn {1})'.format(channelID, cdn), xbmc.LOGERROR)
+		return None
 	pos = url.find('?');
 	if pos > 0:
 		url = url[:pos]
-	link = 'https://mako-streaming.akamaized.net{0}?{1}'.format(url, ticket)
+	link = '{0}{1}?{2}'.format(host, url, ticket)
```

Both new `linkDetails` keys default to the existing hardcoded values, so no other channel changes behaviour.

The `if ticket is None` guard is a separate small fix worth taking regardless. `GetTicket()` returns `None` when `caseId != '1'`, and the return value is currently unchecked — so a refused ticket builds `…index.m3u8?None` and hands it to the player, producing exactly the slow-hang + "Error creating demuxer" signature above. It is latent today (all five tickets currently succeed), but it turns a clean error into a confusing 20-second hang.

## Two other things noticed while testing

These are **not** in this PR, just flagged:

1. **`?b-in-range=…` / `?as=1` on live entries are dead weight.** `WatchLive()` strips the query at `pos = url.find('?')` before building the URL, so those params only ever reach the entitlements `lp=` argument and never affect the stream. The `ch_12`/`ch_12b2`/`ch_12b3` entries look like they differ by bitrate but don't. I kept them in this PR to hold the diff to the actual fix.

2. **`keshet.py` `GetLink()` — unguarded `int(media["cdnLB"])`.** This is the crash fixed in 3.9.7 for #284; the guard does not appear to be present on that line in 4.0.0. It will break VOD again the next time mako returns an empty `cdnLB`.

Also note `GetChannels()`'s `var makoliveJson ='(.*?)';` regex now matches zero times — mako's live page is Next.js and no longer contains that blob.

## Verification you can reproduce

Ticket, then master, then best variant, then a ranged GET on the first and last segment. The distinction that matters: a **fast** 403 means a token/auth problem, while **200 master + 404 segments** means a dead origin behind a live cache — the latter is what produces the long hang. Checking only the master playlist gives a false "stream is fine" result on all four broken entries.

Happy to convert this to an issue instead if you'd rather regenerate `channels.json` yourself, or to split commit 2 into its own PR.
